### PR TITLE
Some minor fixes and improvements

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -1690,7 +1690,6 @@ body {
 }
 .callout-title-inner {
     font-weight: normal;
-    width: 100%;
 }
 .callout-content {
     font-family: var(--font-secondary);

--- a/theme.css
+++ b/theme.css
@@ -945,7 +945,18 @@ body:not(:not(.hide-titlebar-buttons)) .titlebar-button-container:not(:hover) {
     background-color: transparent !important;
  }
  
+/* hide status bar*/
+body:not(.is-mobile):not(:not(.hide-status-bar)) .status-bar:not(:hover) {
+    opacity: 0;
+}
 
+body:not(.is-mobile):not(:not(.hide-status-bar)):not(.opacity-hide) .status-bar:not(:hover) {
+    height: 1em;
+}
+
+.status-bar {
+    transition: .25s;
+}
 
  /* hide file explorer buttons */
 body:not(:not(.hide-file-buttons)) .nav-buttons-container:not(:hover) {
@@ -6767,6 +6778,11 @@ settings:
     -
         id: hide-view-header
         title: Hide View Header
+        type: class-toggle
+        default: true
+    -
+        id: hide-status-bar
+        title: Hide Status Bar
         type: class-toggle
         default: true
     -

--- a/theme.css
+++ b/theme.css
@@ -741,7 +741,7 @@ body:not(:not(.flat-mode)) {
 
 /* hide ribbon */
 body:not(:not(.hide-ribbon)):not(.opacity-hide) .workspace-ribbon:not(:hover) {
-    width: 0.55em;
+    width: 0.55m;
     max-width: 0.55em;
     min-width: 0px;
     padding: 0.5px;
@@ -935,8 +935,8 @@ body:not(.is-mobile):not(:not(.hide-view-header)):not(.opacity-hide) .view-heade
 
  
 body:not(:not(.hide-titlebar-buttons)) .titlebar-button-container:not(:hover) {
-    transition-delay: all 1s !important;
-    opacity: 0;
+transition-delay: all 1s !important;
+opacity: 0;
 }
 
 
@@ -957,6 +957,8 @@ body:not(.is-mobile):not(:not(.hide-status-bar)):not(.opacity-hide) .status-bar:
 .status-bar {
     transition: .25s;
 }
+ 
+
 
  /* hide file explorer buttons */
 body:not(:not(.hide-file-buttons)) .nav-buttons-container:not(:hover) {
@@ -1189,9 +1191,10 @@ body {
 
 /* make space for floating metadata in edit mode */
 [data-type=markdown][data-mode=source] .is-live-preview.show-properties .cm-contentContainer {
-margin-top: var(--inline-title-size);
-} [data-type=markdown][data-mode=source] .is-live-preview.show-properties .metadata-container {
-    margin-top: 3rem;
+margin-top: calc(3.5em + var(--inline-title-size));
+}
+ [data-type=markdown][data-mode=source] .is-live-preview.show-properties .metadata-container {
+    margin-top: 3.5rem;
 }
 
 
@@ -1881,6 +1884,7 @@ body {
   --callout-icon: lucide-clipboard-check;
 }
 .callout[data-callout="<3"],
+.callout[data-callout="like"],
 .callout[data-callout="heart"],
 .callout[data-callout="love"] {
   --callout-color: var(--color-red-rgb);
@@ -1906,7 +1910,7 @@ body {
 .callout[data-callout="n"],
 .callout[data-callout="next"],
 .callout[data-callout="arrow"],
-.callout[data-callout="navigation"]{
+.callout[data-callout="navigation"] {
   --callout-color: var(--color-green-rgb);
   --callout-icon: lucide-arrow-right;
 }
@@ -2168,8 +2172,6 @@ border-radius: var(--radius-s);
 }
 
 
-
-
 /* ============== paragraph spacing =========== */
 body {
     --p-indent: 15px;
@@ -2252,8 +2254,22 @@ body {
     }
 
    
+/* Links Focused by Keyboard */
 
+.theme-dark a:focus-visible {
+    --link-color: hsl(var(--accent-h), var(--accent-s), 88%) !important;
+    color: hsl(var(--accent-h), var(--accent-s), 88%) !important;
+    text-shadow: 0px 0px 40px hsl(var(--accent-h), var(--accent-s), 75%) , 0px 0px 10px hsl(var(--accent-h), var(--accent-s),50%) ;
+    text-decoration: underline var(--link-decoration-color-active) solid var(--link-decoration-thickness) !important;
+    opacity: 1;
+    --link-unresolved-opacity: 1;
+
+}
     
+.theme-light a:focus-visible {
+    font-weight: 800;
+    text-decoration-thickness: 4px;
+}
 
 /* =============== lists ============ */
 body {
@@ -7036,4 +7052,3 @@ settings:
 
 
 */
-

--- a/theme.css
+++ b/theme.css
@@ -741,8 +741,8 @@ body:not(:not(.flat-mode)) {
 
 /* hide ribbon */
 body:not(:not(.hide-ribbon)):not(.opacity-hide) .workspace-ribbon:not(:hover) {
-    width: 0px;
-    max-width: 0px;
+    width: 0.55em;
+    max-width: 0.55em;
     min-width: 0px;
     padding: 0.5px;
     margin-right: 0px;
@@ -935,10 +935,8 @@ body:not(.is-mobile):not(:not(.hide-view-header)):not(.opacity-hide) .view-heade
 
  
 body:not(:not(.hide-titlebar-buttons)) .titlebar-button-container:not(:hover) {
-height: 30px;
-width: 30px;
-transition-delay: all 1s !important;
-opacity: 0;
+    transition-delay: all 1s !important;
+    opacity: 0;
 }
 
 
@@ -958,7 +956,7 @@ body:not(.opacity-hide):not(:not(.hide-file-buttons)) .nav-buttons-container:not
     padding:2px;
  }
 .nav-buttons-container {
-    transition: 0.1s opacity, 0.5s height, 0.5s padding;
+    transition: 0.1s opacity, 0.25s height, 0.25s padding;
 }
 /* =============== sidebar ======== */
 .workspace-leaf-content {


### PR DESCRIPTION
- Fix #21 by restoring the default box size of `titlebar-button-container`, which is 0.
- Fix the overlapping of the callout editing button with the folding button by restoring the default width of the callout title.
- Fix #22 by setting the width of `workspace-ribbon` to `0.55em`. (temporary workaround)
- Make the animation of `nav-buttons-container` look better on Windows by reducing its time to `0.25s`.
- Fold the status bar.