### PR TITLE
Fade out more inactive elements

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -243,21 +243,30 @@ body {
     --active-line-size: inherit;
 }
 
-
-.active-line-highlight .cm-line,
-.active-line-highlight .callout,
-.active-line-highlight img,
-.active-line-highlight .inline-title {
+.active-line-highlight :is(
+    .cm-line,
+    .callout,
+    .math-block,
+    .table-wrapper,
+    .media-embed,
+    img,
+    .inline-title,
+    .metadata-container) {
     transition: opacity 0.2s, font-size 0.2s !important;
 }
 
-.active-line-highlight .cm-active.cm-line,
+.active-line-highlight :is(
+    .cm-active.cm-line,
+    .callout:hover,
+    .math-block:hover,
+    .table-wrapper:hover,
+    .media-embed:hover,
+    img:hover,
+    .markdown-source-view .inline-title:hover,
+    .markdown-source-view .metadata-container:hover),
 .active-line-highlight.opacity-hover .cm-line:hover,
-.active-line-highlight .callout:hover,
-.active-line-highlight img:hover,
-.active-line-highlight .markdown-source-view .inline-title:hover,
 .source-line-effect .markdown-source-view:not(.is-live-preview) .cm-line,
-.preview-line-effect .markdown-source-view.is-live-preview  .cm-line {
+.preview-line-effect .markdown-source-view.is-live-preview .cm-line {
     opacity: 1 !important;
     filter: none !important;
 }
@@ -268,10 +277,18 @@ body {
     font-size: var(--active-line-size) !important;
 }
 
-.active-line-highlight .cm-contentContainer .cm-line, .active-line-highlight .cm-contentContainer img, .active-line-highlight .cm-contentContainer .callout,
-.active-line-highlight .markdown-source-view .inline-title {
-   opacity: var(--inactive-line-opacity);
-   filter: blur(var(--inactive-line-blur));
+.active-line-highlight .cm-contentContainer :is(
+    .cm-line,
+    .callout,
+    .math-block,
+    .table-wrapper,
+    .media-embed,
+    img),
+.active-line-highlight .markdown-source-view :is(
+    .inline-title,
+    .metadata-container) {
+    opacity: var(--inactive-line-opacity);
+    filter: blur(var(--inactive-line-blur));
 }
 
 /*

--- a/theme.css
+++ b/theme.css
@@ -260,10 +260,12 @@ body {
     .callout:hover,
     .math-block:hover,
     .table-wrapper:hover,
+    .table-wrapper:focus-within,
     .media-embed:hover,
     img:hover,
     .markdown-source-view .inline-title:hover,
-    .markdown-source-view .metadata-container:hover),
+    .markdown-source-view .metadata-container:hover,
+    .markdown-source-view .metadata-container:focus-within),
 .active-line-highlight.opacity-hover .cm-line:hover,
 .source-line-effect .markdown-source-view:not(.is-live-preview) .cm-line,
 .preview-line-effect .markdown-source-view.is-live-preview .cm-line {


### PR DESCRIPTION
Hi. Is it necessary to fade out inactive tables, math blocks, media embeds, and properties? I'm trying to do that in this pr.

still don't know whether or not this would break something on macOS.